### PR TITLE
tests: add some basic syntax checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: SQL Syntax check
+
+on: [push, pull_request]
+
+jobs:
+  sql-test:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install PG
+      run: sudo apt install -y postgresql
+
+    - name: Enable trust auth
+      run: echo "local all all      trust" | sudo tee /etc/postgresql/13/main/pg_hba.conf
+
+    - name: (Re)start PG server
+      run: sudo service postgresql restart
+
+    - name: Load SQL
+      run: make tests

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,6 @@ rpm-%: $(generated)
 		--define 'major_version $(short_ver)' \
 		--define 'minor_version $(subst -,.,$(subst $(short_ver)-,,$(long_ver)))'
 	$(RM) aiven-extras-rpm-src.tar
+
+tests:
+	./test/check-sql.sh

--- a/sql/aiven_extras.sql
+++ b/sql/aiven_extras.sql
@@ -71,7 +71,7 @@ CREATE FUNCTION aiven_extras.dblink_slot_create_or_drop(
     arg_action TEXT
 )
 RETURNS VOID LANGUAGE plpgsql
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 DECLARE
     l_clear_search_path TEXT := 'SET search_path TO pg_catalog, pg_temp;';
@@ -111,7 +111,7 @@ CREATE FUNCTION aiven_extras.pg_create_subscription(
 )
 RETURNS VOID LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     IF (arg_slot_create IS TRUE) THEN
@@ -130,7 +130,7 @@ CREATE FUNCTION aiven_extras.pg_alter_subscription_disable(
 )
 RETURNS VOID LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     EXECUTE pg_catalog.format('ALTER SUBSCRIPTION %I DISABLE', arg_subscription_name);
@@ -144,7 +144,7 @@ CREATE FUNCTION aiven_extras.pg_alter_subscription_enable(
 )
 RETURNS VOID LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     EXECUTE pg_catalog.format('ALTER SUBSCRIPTION %I ENABLE', arg_subscription_name);
@@ -159,7 +159,7 @@ CREATE FUNCTION aiven_extras.pg_alter_subscription_refresh_publication(
 )
 RETURNS VOID LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     EXECUTE pg_catalog.format(
@@ -174,7 +174,7 @@ CREATE FUNCTION aiven_extras.pg_drop_subscription(
 )
 RETURNS VOID LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 DECLARE
     l_slot_name TEXT;
@@ -202,7 +202,7 @@ CREATE FUNCTION aiven_extras.pg_create_publication_for_all_tables(
 )
 RETURNS VOID LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     EXECUTE pg_catalog.format('CREATE PUBLICATION %I FOR ALL TABLES WITH (publish = %I)', arg_publication_name, arg_publish);
@@ -214,7 +214,7 @@ DROP FUNCTION IF EXISTS aiven_extras.pg_list_all_subscriptions();
 CREATE FUNCTION aiven_extras.pg_list_all_subscriptions()
 RETURNS SETOF aiven_extras.aiven_pg_subscription LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     RETURN QUERY
@@ -230,7 +230,7 @@ CREATE FUNCTION aiven_extras.session_replication_role(
 )
 RETURNS TEXT LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     RETURN pg_catalog.set_config('session_replication_role', arg_parameter, false);
@@ -242,7 +242,7 @@ DROP FUNCTION IF EXISTS aiven_extras.auto_explain_load();
 CREATE FUNCTION aiven_extras.auto_explain_load()
 RETURNS VOID LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     LOAD 'auto_explain';
@@ -256,7 +256,7 @@ CREATE FUNCTION aiven_extras.set_auto_explain_log_analyze(
 )
 RETURNS TEXT LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     RETURN pg_catalog.set_config('auto_explain.log_analyze', arg_parameter, false);
@@ -270,7 +270,7 @@ CREATE FUNCTION aiven_extras.set_auto_explain_log_format(
 )
 RETURNS TEXT LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     RETURN pg_catalog.set_config('auto_explain.log_format', arg_parameter, false);
@@ -284,7 +284,7 @@ CREATE FUNCTION aiven_extras.set_auto_explain_log_min_duration(
 )
 RETURNS TEXT LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     RETURN pg_catalog.set_config('auto_explain.log_min_duration', arg_parameter, false);
@@ -298,7 +298,7 @@ CREATE FUNCTION aiven_extras.set_auto_explain_log_timing(
 )
 RETURNS TEXT LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     RETURN pg_catalog.set_config('auto_explain.log_timing', arg_parameter, false);
@@ -312,7 +312,7 @@ CREATE FUNCTION aiven_extras.set_auto_explain_log_buffers(
 )
 RETURNS TEXT LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     RETURN pg_catalog.set_config('auto_explain.log_buffers', arg_parameter, false);
@@ -326,7 +326,7 @@ CREATE FUNCTION aiven_extras.set_auto_explain_log_verbose(
 )
 RETURNS TEXT LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     RETURN pg_catalog.set_config('auto_explain.log_verbose', arg_parameter, false);
@@ -340,7 +340,7 @@ CREATE FUNCTION aiven_extras.set_auto_explain_log_nested_statements(
 )
 RETURNS TEXT LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = aiven_extras, pg_catalog, pg_temp
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     RETURN pg_catalog.set_config('auto_explain.log_nested_statements', arg_parameter, false);
@@ -352,7 +352,7 @@ DROP FUNCTION IF EXISTS aiven_extras.claim_public_schema_ownership();
 CREATE FUNCTION aiven_extras.claim_public_schema_ownership()
 RETURNS VOID LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     EXECUTE pg_catalog.format('ALTER SCHEMA public OWNER TO %I', session_user);
@@ -388,7 +388,7 @@ DROP FUNCTION IF EXISTS aiven_extras.pg_stat_replication_list();
 CREATE FUNCTION aiven_extras.pg_stat_replication_list()
 RETURNS SETOF aiven_extras.aiven_pg_stat_replication LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 BEGIN
     RETURN QUERY
@@ -419,7 +419,7 @@ CREATE FUNCTION aiven_extras.pg_create_publication(
 )
 RETURNS VOID LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = pg_catalog, pg_temp, aiven_extras
+SET search_path = pg_catalog, aiven_extras
 AS $$
 DECLARE
   l_ident TEXT;

--- a/test/check-sql.sh
+++ b/test/check-sql.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+sql_files=$(ls sql/*.sql)
+psql -v ON_ERROR_STOP=1 -U postgres -c "CREATE SCHEMA aiven_extras;"
+for file in ${sql_files}
+do
+    psql -v ON_ERROR_STOP=1 -U postgres -f ${file}
+    echo "File ${file} passes syntax check"
+done
+


### PR DESCRIPTION
Creating / Updating an extension seems to be a lazy process, in that a
successful update does not guarantee the functions in the SQL scripts
have been loaded by the server. This is intended as a workaround that
limitation, catching any syntax errors early.