### PR TITLE
pgaudit: Add set_pgaudit_parameter function [BF-614]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-short_ver = 1.1.3
-last_ver = 1.1.2
+short_ver = 1.1.4
+last_ver = 1.1.3
 long_ver = $(shell git describe --long 2>/dev/null || echo $(short_ver)-0-unknown-g`git describe --always`)
 generated = \
 	build/aiven_extras.control \

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Usage
 | set_auto_explain_log_nested_statements    | text                                         | arg_parameter text                                                                                                                                                               |
 | set_auto_explain_log_timing               | text                                         | arg_parameter text                                                                                                                                                               |
 | set_auto_explain_log_verbose              | text                                         | arg_parameter text                                                                                                                                                               |
+| set_pgaudit_parameter                     | void                                         | arg_parameter text, arg_database text, arg_value text                                                                                                                            |
 
 Examples
 --------


### PR DESCRIPTION
This adds a function to modify a limited set of pgaudit configuration
parameters for a given database from an otherwise unprivileged user. 
Databases owned by a superuser cannot have their pgaudit configuration 
changed.