### PR TITLE
fix workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       run: sudo apt install -y postgresql
 
     - name: Enable trust auth
-      run: echo "local all all      trust" | sudo tee /etc/postgresql/13/main/pg_hba.conf
+      run: echo "local all all      trust" | sudo tee /etc/postgresql/*/main/pg_hba.conf
 
     - name: (Re)start PG server
       run: sudo service postgresql restart


### PR DESCRIPTION
The Postgres version in the container image has been updated from 13 to
14. Use a wildcard instead of a major version number in the path to
pg_hba.conf, in order to avoid this happening again with the next
update.