### PR TITLE
Add aiven_extras C code to the extension [BF-1513]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,1 @@
 *.spec export-ignore
-*.in
-sql/aiven_extras.sql export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.spec export-ignore
+*.in
+sql/aiven_extras.sql export-ignore

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,23 +1,48 @@
-name: SQL Syntax check
+name: Extension tests
 
 on: [push, pull_request]
 
 jobs:
   sql-test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
+    env:
+      PGPORT: 54322
+      PGUSER: postgres
     strategy:
-      max-parallel: 4
+      matrix:
+        postgresql_version: [11, 12, 13, 14, 15]
+        experimental: [false]
+        repo: ["pgdg"]
+        # Define the current dev version to be experimental
+        include:
+          - postgresql_version: 16
+            experimental: true
+            repo: "pgdg-snapshot"
     steps:
     - uses: actions/checkout@v1
 
     - name: Install PG
-      run: sudo apt install -y postgresql
+      run: |
+        sudo apt update
+        sudo apt install curl ca-certificates gnupg
+        curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null
+        sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-${{ matrix.repo }} main ${{ matrix.postgresql_version }}" > /etc/apt/sources.list.d/pgdg.list'
+        sudo apt update
+        sudo apt install postgresql-${{matrix.postgresql_version}} postgresql-contrib-${{matrix.postgresql_version}} postgresql-server-dev-${{matrix.postgresql_version}}
 
-    - name: Enable trust auth
-      run: echo "local all all      trust" | sudo tee /etc/postgresql/*/main/pg_hba.conf
+    - name: Setup cluster
+      run: |
+        sudo pg_createcluster ${{matrix.postgresql_version}} test -p ${PGPORT} -- --auth-local=trust
 
     - name: (Re)start PG server
-      run: sudo service postgresql restart
+      run: |
+        sudo pg_ctlcluster ${{matrix.postgresql_version}} test start
+        psql -c "ALTER SYSTEM SET wal_level = 'logical'"
+        sudo pg_ctlcluster ${{matrix.postgresql_version}} test restart
 
-    - name: Load SQL
-      run: make tests
+    - name: Install
+      run: sudo PATH=/usr/lib/postgresql/${{matrix.postgresql_version}}/bin:$PATH make install
+
+    - name: Run tests
+      run: PATH=/usr/lib/postgresql/${{matrix.postgresql_version}}/bin:$PATH make installcheck

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ src/*.o
 *.so
 aiven_extras.control
 aiven-extras-rpm-src.tar
+test/out

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *~
-/build/
 /rpm/
+src/*.o
+*.so
+aiven_extras.control
+aiven-extras-rpm-src.tar

--- a/Makefile
+++ b/Makefile
@@ -2,40 +2,43 @@ short_ver = 1.1.7
 last_ver = 1.1.6
 long_ver = $(shell git describe --long 2>/dev/null || echo $(short_ver)-0-unknown-g`git describe --always`)
 generated = \
-	build/aiven_extras.control \
-	build/sql/aiven_extras--$(short_ver).sql \
-	build/sql/aiven_extras--$(last_ver)--$(short_ver).sql
-
+	aiven_extras.control \
+	sql/aiven_extras--$(short_ver).sql 
 # for downstream packager
 RPM_MINOR_VERSION_SUFFIX ?=
 
-rpm: rpm-9.6 rpm-10 rpm-11 rpm-12 rpm-13 rpm-14
+# Extension packaging
+EXTENSION = aiven_extras
+MODULE_big = aiven_extras
+OBJS = src/standby_slots.o
+PG_CONFIG ?= pg_config
+DATA = $(wildcard sql/*--*.sql)
+PGXS := $(shell $(PG_CONFIG) --pgxs)
+EXTRA_CLEAN = aiven_extras.control aiven-extras-rpm-src.tar
 
-clean:
-	rm -rf build/ rpm/ aiven-extras-rpm-src.tar
+include $(PGXS)
 
-build/aiven_extras.control: aiven_extras.control.in
+rpm: rpm-96 rpm-10 rpm-11 rpm-12 rpm-13 rpm-14
+
+
+aiven_extras.control: aiven_extras.control.in
 	mkdir -p $(@D)
 	sed -e 's,__short_ver__,$(short_ver),g' < $^ > $@
 
-build/sql/aiven_extras--$(short_ver).sql: sql/aiven_extras.sql
-	mkdir -p $(@D)
-	cp -fp $^ $@
-
-build/sql/aiven_extras--$(last_ver)--$(short_ver).sql: sql/aiven_extras.sql
+sql/aiven_extras--$(short_ver).sql: sql/aiven_extras.sql
 	mkdir -p $(@D)
 	cp -fp $^ $@
 
 rpm-%: $(generated)
-	git archive --output=aiven-extras-rpm-src.tar --prefix=aiven-extras/ HEAD
-	# add generated files to the tar, they're not in git repository
-	tar -r -f aiven-extras-rpm-src.tar \
-		--transform=s,build/,aiven-extras/, \
-		$(generated)
-	rpmbuild -bb aiven-extras.spec \
+	git archive --output=aiven-extras-rpm-src.tar \
+				--prefix=aiven-extras/sql/ --add-file sql/aiven_extras--$(short_ver).sql \
+				--prefix=aiven-extras/ HEAD --add-file aiven_extras.control
+	QA_RPATHS=0x0002 rpmbuild -bb aiven-extras.spec \
 		--define '_topdir $(PWD)/rpm' \
 		--define '_sourcedir $(CURDIR)' \
+		--define "_buildrootdir $(CURDIR)/rpm/BUILDROOT" \
 		--define "packagenameversion $(subst .,,$(subst rpm-,,$@))" \
+		--define "pginstdir /usr/pgsql-$(subst rpm-,,$@)" \
 		--define "pgmajorversion $(subst rpm-,,$@)" \
 		--define 'major_version $(short_ver)' \
 		--define 'minor_version $(subst -,.,$(subst $(short_ver)-,,$(long_ver)))$(RPM_MINOR_VERSION_SUFFIX)'

--- a/aiven-extras.spec
+++ b/aiven-extras.spec
@@ -1,4 +1,5 @@
 %global sname   aiven-extras
+%global extname aiven_extras
 %undefine _missing_build_ids_terminate_build
 
 Name:           %{sname}_%{packagenameversion}
@@ -8,6 +9,8 @@ Url:            http://github.com/aiven/aiven-extras
 Summary:        Aiven PostgreSQL extras extension
 License:        ASL 2.0
 Source0:        aiven-extras-rpm-src.tar
+BuildRequires:	postgresql%{pgmajorversion}-devel pgdg-srpm-macros
+Requires:	postgresql%{pgmajorversion}-server
 BuildArch:	noarch
 
 %description
@@ -19,22 +22,37 @@ have full PostgreSQL superuser rights.
 %prep
 %setup -n %{sname}
 
-
 %install
+%{__rm} -rf %{buildroot}
+
+USE_PGXS=1 PATH=%{pginstdir}/bin/:$PATH %{__make} %{?_smp_mflags} install DESTDIR=%{buildroot}
 mkdir -p %{buildroot}/usr/share/doc/aiven-extras-%{pgmajorversion}
 mkdir -p %{buildroot}/usr/share/licenses/aiven-extras-%{pgmajorversion}
-mkdir -p %{buildroot}/usr/pgsql-%{pgmajorversion}/share/extension
 %{__install} -D -m 644 README.md %{buildroot}/usr/share/doc/aiven-extras-%{pgmajorversion}/
 %{__install} -D -m 644 LICENSE %{buildroot}/usr/share/licenses/aiven-extras-%{pgmajorversion}/
-%{__install} -D -m 644 sql/*.sql %{buildroot}/usr/pgsql-%{pgmajorversion}/share/extension/
-%{__install} -D -m 644 aiven_extras.control %{buildroot}/usr/pgsql-%{pgmajorversion}/share/extension/
+
+%clean
+%{__rm} -rf %{buildroot}
+
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
 
 %files
 %defattr(-, root, root)
-/usr/pgsql-%{pgmajorversion}/share/extension/
 /usr/share/doc/aiven-extras-%{pgmajorversion}/
 /usr/share/licenses/aiven-extras-%{pgmajorversion}/
 
+%defattr(644,root,root,755)
+%{pginstdir}/lib/%{extname}.so
+%{pginstdir}/share/extension/%{extname}--*.sql
+%{pginstdir}/share/extension/%{extname}.control
+%if %{pgmajorversion} >= 11 && %{pgmajorversion} < 90
+ %if 0%{?rhel} && 0%{?rhel} <= 6
+ %else
+ %{pginstdir}/lib/bitcode/%{extname}*.bc
+ %{pginstdir}/lib/bitcode/%{extname}/src/*.bc
+ %endif
+%endif
 
 %changelog
 * Tue Aug 7 2018 Hannu Valtonen <hannu.valtonen@aiven.io> - 1.0.0

--- a/aiven_extras.control.in
+++ b/aiven_extras.control.in
@@ -2,3 +2,4 @@ comment = 'aiven_extras'
 default_version = '__short_ver__'
 relocatable = false
 schema = 'aiven_extras'
+module_pathname = '$libdir/aiven_extras'

--- a/sql/aiven_extras.sql
+++ b/sql/aiven_extras.sql
@@ -571,3 +571,13 @@ PERFORM pg_catalog.set_config('search_path', old_path, true);
 
 END;
 $OUTER$;
+
+-- standby slots fuctions
+CREATE FUNCTION aiven_extras.pg_create_logical_replication_slot_on_standby(
+	slot_name name,
+	plugin name,
+	temporary boolean DEFAULT false,
+	twophase boolean DEFAULT false,
+	OUT slot_name name, OUT lsn pg_lsn)
+AS 'MODULE_PATHNAME', 'standby_slot_create'
+LANGUAGE C;

--- a/src/standby_slots.c
+++ b/src/standby_slots.c
@@ -1,0 +1,122 @@
+#include "postgres.h"
+#include "fmgr.h"
+#include "funcapi.h"
+#include "miscadmin.h"
+#include "access/xlogreader.h"
+#include "access/xlogutils.h"
+#include "replication/logical.h"
+#include "replication/slot.h"
+#include "replication/walreceiver.h"
+#if PG_VERSION_NUM >= 120000 && PG_VERSION_NUM < 130000
+#include "replication/logicalfuncs.h"
+#endif
+#include "utils/pg_lsn.h"
+
+PG_MODULE_MAGIC;
+
+PG_FUNCTION_INFO_V1(standby_slot_create);
+	Datum
+standby_slot_create(PG_FUNCTION_ARGS)
+{
+	Name		name = PG_GETARG_NAME(0);
+	Name		plugin = PG_GETARG_NAME(1);
+	bool		temporary = PG_GETARG_BOOL(2);
+	bool		two_phase = PG_GETARG_BOOL(3);
+	Datum		result;
+	TupleDesc	tupdesc;
+	HeapTuple	tuple;
+	Datum		values[2];
+	bool		nulls[2];
+	LogicalDecodingContext *ctx = NULL;
+
+	if(!RecoveryInProgress())
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("This function can only be used on a standby server.")));
+
+	/*
+	 * FIXME: add a ProcessUtility hook disallowing to turn hot_standby_feedback off.
+	 * This will require loading through shared_preload_libraries though.
+	 */
+	if(!hot_standby_feedback)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("Logical replication slots on a standby require hot_standby_feedback set to 'on'")));
+
+	if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+		elog(ERROR, "return type must be a row type");
+
+	if (!superuser() && !has_rolreplication(GetUserId()))
+		ereport(ERROR,
+				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
+				 errmsg("must be superuser or replication role to use replication slots")));
+
+	CheckSlotRequirements();
+	if (wal_level < WAL_LEVEL_LOGICAL)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("logical decoding requires wal_level >= logical")));
+
+	if (MyDatabaseId == InvalidOid)
+		ereport(ERROR,
+				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
+				 errmsg("logical decoding requires a database connection")));
+#if PG_VERSION_NUM < 140000
+	if (two_phase)
+		ereport(ERROR,
+				(errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+				 errmsg("two phase commits are only available on PG >= 14")));
+#endif
+	/* Don't bother returning anything else than void for now */
+	Assert(!MyReplicationSlot);
+
+	/*
+	 * Acquire a logical decoding slot, this will check for conflicting names.
+	 * Initially create persistent slot as ephemeral - that allows us to
+	 * nicely handle errors during initialization because it'll get dropped if
+	 * this transaction fails. We'll make it persistent at the end. Temporary
+	 * slots can be created as temporary from beginning as they get dropped on
+	 * error as well.
+	 */
+	ReplicationSlotCreate(NameStr(*name), true,
+			temporary ? RS_TEMPORARY : RS_EPHEMERAL
+#if PG_VERSION_NUM >= 140000
+			, two_phase
+#endif
+			);
+
+	/*
+	 * Create logical decoding context to find start point or, if we don't
+	 * need it, to 1) bump slot's restart_lsn and xmin 2) check plugin sanity.
+	 *
+	 * Note: when !find_startpoint this is still important, because it's at
+	 * this point that the output plugin is validated.
+	 */
+	ctx = CreateInitDecodingContext(NameStr(*plugin), NIL,
+			false,	/* just catalogs is OK */
+			InvalidXLogRecPtr,
+#if PG_VERSION_NUM >= 130000
+			XL_ROUTINE(.page_read = read_local_xlog_page,
+				.segment_open = wal_segment_open,
+				.segment_close = wal_segment_close),
+#elif PG_VERSION_NUM >= 120000
+			logical_read_local_xlog_page,
+#endif
+			NULL, NULL, NULL);
+
+	/* don't need the decoding context anymore */
+	FreeDecodingContext(ctx);
+
+	values[0] = NameGetDatum(&MyReplicationSlot->data.name);
+	values[1] = LSNGetDatum(MyReplicationSlot->data.confirmed_flush);
+
+	memset(nulls, 0, sizeof(nulls));
+
+	tuple = heap_form_tuple(tupdesc, values, nulls);
+	result = HeapTupleGetDatum(tuple);
+
+	if (!temporary)
+		ReplicationSlotPersist();
+	ReplicationSlotRelease();
+	PG_RETURN_DATUM(result);
+}

--- a/test/expected/test_dblink_create_or_drop.out
+++ b/test/expected/test_dblink_create_or_drop.out
@@ -1,0 +1,24 @@
+CREATE EXTENSION aiven_extras;
+SELECT aiven_extras.dblink_slot_create_or_drop(format('dbname=%I port=%s', current_database(), current_setting('port')), 'test_slot', 'create');
+ dblink_slot_create_or_drop 
+----------------------------
+ 
+(1 row)
+
+SELECT slot_name from pg_replication_slots where slot_name = 'test_slot';
+ slot_name 
+-----------
+ test_slot
+(1 row)
+
+SELECT aiven_extras.dblink_slot_create_or_drop(format('dbname=%I port=%s', current_database(), current_setting('port')), 'test_slot', 'drop');
+ dblink_slot_create_or_drop 
+----------------------------
+ 
+(1 row)
+
+SELECT slot_name from pg_replication_slots where slot_name = 'test_slot';
+ slot_name 
+-----------
+(0 rows)
+

--- a/test/sql/test_dblink_create_or_drop.sql
+++ b/test/sql/test_dblink_create_or_drop.sql
@@ -1,0 +1,5 @@
+CREATE EXTENSION aiven_extras;
+SELECT aiven_extras.dblink_slot_create_or_drop(format('dbname=%I port=%s', current_database(), current_setting('port')), 'test_slot', 'create');
+SELECT slot_name from pg_replication_slots where slot_name = 'test_slot';
+SELECT aiven_extras.dblink_slot_create_or_drop(format('dbname=%I port=%s', current_database(), current_setting('port')), 'test_slot', 'drop');
+SELECT slot_name from pg_replication_slots where slot_name = 'test_slot';


### PR DESCRIPTION
This extension only provides one function for now, to allow for the creation of logical replication slots on a standby server.

To do so, the build system had to be changed quite a bit to incorporate the PGXS infrastructure.

I'm not too familiar with the rpm build system, so I took inspiration from how things are done at yum.postgresql.org.

One thing in particular that I don't know how to fix properly, is that I had to disable rpath checks.

It is now tested against all supported and upcoming versions of PG. 

We still need to add proper tests here, but at least the basics are checked.