### PR TITLE
Add support for PG19

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,12 +11,12 @@ jobs:
       PGUSER: postgres
     strategy:
       matrix:
-        postgresql_version: [12, 13, 14, 15, 16, 17, 18]
+        postgresql_version: [12, 13, 14, 15, 16, 17, 18, 19]
         experimental: [false]
         repo: ["pgdg"]
         # Define the current dev version to be experimental
         include:
-          - postgresql_version: 18
+          - postgresql_version: 19
             experimental: true
             repo: "pgdg-snapshot"
     steps:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ EXTRA_CLEAN = aiven_extras.control aiven-extras-rpm-src.tar
 
 include $(PGXS)
 
-rpm: rpm-12 rpm-13 rpm-14 rpm-15 rpm-16 rpm-17 rpm-18
+rpm: rpm-12 rpm-13 rpm-14 rpm-15 rpm-16 rpm-17 rpm-18 rpm-19
 
 aiven_extras.control: aiven_extras.control.in
 	mkdir -p $(@D)

--- a/src/aiven_extras.c
+++ b/src/aiven_extras.c
@@ -53,7 +53,11 @@ standby_slot_create(PG_FUNCTION_ARGS)
 				(errcode(ERRCODE_INSUFFICIENT_PRIVILEGE),
 				 errmsg("must be superuser or replication role to use replication slots")));
 
-	CheckSlotRequirements();
+	CheckSlotRequirements(
+#if PG_VERSION_NUM >= 190000
+		false /* no repack */
+#endif
+	);
 	if (wal_level < WAL_LEVEL_LOGICAL)
 		ereport(ERROR,
 				(errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
@@ -97,6 +101,9 @@ standby_slot_create(PG_FUNCTION_ARGS)
 #if PG_VERSION_NUM >= 140000
 			, two_phase
 #endif
+#if PG_VERSION_NUM >= 190000
+			, false /* no repack */
+#endif
 #if PG_VERSION_NUM >= 170000
 			, failover
 			, synced
@@ -112,6 +119,9 @@ standby_slot_create(PG_FUNCTION_ARGS)
 	 */
 	ctx = CreateInitDecodingContext(NameStr(*plugin), NIL,
 			false,	/* just catalogs is OK */
+#if PG_VERSION_NUM >= 190000
+			false,	/* not repack */
+#endif
 			InvalidXLogRecPtr,
 #if PG_VERSION_NUM >= 130000
 			XL_ROUTINE(.page_read = read_local_xlog_page,


### PR DESCRIPTION
PG19 adds a `repack` replication slot parameter that we need to account
for in `CheckSlotRequirements()`, `ReplicationSlotCreate()`, and
`CreateInitDecodingContext()`.

The changes are guarded by `PG_VERSION_NUM` so PG13–18 continue to build.